### PR TITLE
fix/UH2002-PLP-banner: adjust width of ad banner image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1018,7 +1018,7 @@ main {
 }
 
 .ad-banner img {
-    width: 159%;
+    width: 158.1%;
     height: auto; 
 }
 


### PR DESCRIPTION
### se ajustó el width del banner para que no ocupara más allá de la página.
![image](https://github.com/user-attachments/assets/0443352f-d1ae-41e1-965a-1535d95f59a9)
